### PR TITLE
Added redirect data model to python and fix packaging

### DIFF
--- a/demos/python/main.py
+++ b/demos/python/main.py
@@ -11,7 +11,7 @@ def _get_itsme_client():
         private_jwk_set = jwks_file.read()
     client_id = 'client_id'
     redirect_url = 'https://example.com/redirect'
-    environment = itsme.PRODUCTION
+    environment = itsme.AppEnvironments.PRODUCTION
     settings = itsme.ItsmeSettings(
         client_id, redirect_url, private_jwk_set, environment)
     return itsme.Client(settings)
@@ -56,8 +56,8 @@ def redirect_url():
 def request_uri():
     url_config = itsme.UrlConfiguration(
         ['profile', 'email', 'address', 'phone'], 'service_code', 'https://example.com/redirect', '')
-    config = itsme.RequestURIConfiguration(url_config, itsme.ACRAdvanced, 'nonce', 'state', [
-                                           itsme.ClaimCityOfBirth, itsme.ClaimDevice, itsme.ClaimEid, itsme.ClaimNationality])
+    config = itsme.RequestURIConfiguration(url_config, itsme.ACRValues.ACRAdvanced, 'nonce', 'state', [
+                                           itsme.Claims.CityOfBirth, itsme.Claims.Device, itsme.Claims.Eid, itsme.Claims.Nationality])
     data = _get_itsme_client().create_request_uri_payload(config)
     resp = Response(data)
     resp.headers['Content-Type'] = 'text/plain; charset=utf-8'

--- a/demos/python/main.py
+++ b/demos/python/main.py
@@ -4,20 +4,25 @@ import itsme
 
 app = Flask(__name__)
 
+
 def _get_itsme_client():
     private_jwk_set = ''
     with open('../keys/jwks_private.json', 'r') as jwks_file:
         private_jwk_set = jwks_file.read()
-    client_id = 'my_client_id'
-    redirect_url = 'https://example.com/production/redirect'
+    client_id = 'client_id'
+    redirect_url = 'https://example.com/redirect'
     environment = itsme.PRODUCTION
-    settings = itsme.ItsmeSettings(client_id, redirect_url, private_jwk_set, environment)
+    settings = itsme.ItsmeSettings(
+        client_id, redirect_url, private_jwk_set, environment)
     return itsme.Client(settings)
 
-@app.route("/production/login")
+
+@app.route("/login")
 def login():
-    request_uri = 'https://example.com:443/production/request_uri'
-    config = itsme.UrlConfiguration(['profile', 'email', 'address', 'phone'], 'my_service_code', request_uri)
+    request_uri = 'https://example.com:443/request'
+    redirect_uri = 'https://example.com/redirect'
+    config = itsme.UrlConfiguration(
+        ['profile', 'email', 'address', 'phone'], 'service_code', redirect_uri, request_uri)
     itsme_auth_url = _get_itsme_client().get_authentication_url(config)
     body = {
         'url': itsme_auth_url
@@ -26,8 +31,8 @@ def login():
     return resp
 
 
-@app.route("/production/jwks.json")
-def hello():
+@app.route("/jwks")
+def jwks():
     jwks = ""
     with open('../keys/jwks_public.json') as f:
         jwks = f.read()
@@ -36,24 +41,32 @@ def hello():
     return resp
 
 
-@app.route("/production/redirect")
-def redirect():
+@app.route("/redirect")
+def redirect_url():
     code = request.args.get('code')
-    user = _get_itsme_client().get_user_details(code)
+    redirect_uri = 'https://example.com/redirect'
+    redirect_data = itsme.RedirectData(code, redirect_uri)
+    user = _get_itsme_client().get_user_details(redirect_data)
     resp = Response(dumps(user.__dict__, default=lambda o: o.__dict__))
     resp.headers['Content-Type'] = 'application/json'
     return resp
 
 
-@app.route("/production/request")
+@app.route("/request")
 def request_uri():
-    url_config = itsme.UrlConfiguration(['profile', 'email', 'address', 'phone'], 'my_service_code', '')
-    config = itsme.RequestURIConfiguration(url_config, 'tag:sixdots.be,2016-06:acr_advanced', 'nonce', 'state', ['tag:sixdots.be,2016-06:claim_city_of_birth', 'tag:sixdots.be,2016-06:claim_nationality', 'tag:sixdots.be,2017-05:claim_device', 'tag:sixdots.be,2016-06:claim_eid', 'tag:sixdots.be,2017-05:claim_photo'])
+    url_config = itsme.UrlConfiguration(
+        ['profile', 'email', 'address', 'phone'], 'service_code', 'https://example.com/redirect', '')
+    config = itsme.RequestURIConfiguration(url_config, itsme.ACRAdvanced, 'nonce', 'state', [
+                                           itsme.ClaimCityOfBirth, itsme.ClaimDevice, itsme.ClaimEid, itsme.ClaimNationality])
     data = _get_itsme_client().create_request_uri_payload(config)
     resp = Response(data)
     resp.headers['Content-Type'] = 'text/plain; charset=utf-8'
-
     return resp
+
+
+@app.route("/")
+def hello():
+    return "Hello!"
 
 
 if __name__ == '__main__':

--- a/python/itsme/__init__.py
+++ b/python/itsme/__init__.py
@@ -1,1 +1,1 @@
-from .itsme import Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, PRODUCTION, SANDBOX
+from .itsme import Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, RedirectData, PRODUCTION, SANDBOX

--- a/python/itsme/__init__.py
+++ b/python/itsme/__init__.py
@@ -1,1 +1,3 @@
-from .itsme import Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, RedirectData, PRODUCTION, SANDBOX
+from .itsme import (Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, RedirectData, PRODUCTION,
+                    SANDBOX, ACRBasic, ACRAdvanced, ACRSecured, ClaimEid, ClaimCityOfBirth, ClaimNationality,
+                    ClaimDevice, ClaimPhoto)

--- a/python/itsme/__init__.py
+++ b/python/itsme/__init__.py
@@ -1,3 +1,2 @@
-from .itsme import (Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, RedirectData, PRODUCTION,
-                    SANDBOX, ACRBasic, ACRAdvanced, ACRSecured, ClaimEid, ClaimCityOfBirth, ClaimNationality,
-                    ClaimDevice, ClaimPhoto)
+from .itsme import (Client, User, ItsmeSettings, UrlConfiguration, RequestURIConfiguration, RedirectData,
+                    AppEnvironments, Claims, ACRValues)

--- a/python/itsme/itsme.py
+++ b/python/itsme/itsme.py
@@ -1,6 +1,5 @@
 from json import loads, dumps
-import typing
-from typing import Dict, List, Tuple
+from typing import List
 from ctypes import CDLL, c_char_p, Structure
 from os.path import abspath, dirname
 from sys import platform as operating_system
@@ -33,18 +32,17 @@ class User(object):
         self.sub = user.get('sub', '')
         self.birthdate = user.get('birthdate', '')
         self.city_of_birth = user.get('city_of_birth', '')
-        if 'eid' in user:
+        self.photo = user.get('photo', '')
+        if (user['eid']):
             self.eid = Eid(user['eid'])
-        if 'address' in user:
+        if (user['address']):
             self.address = Address(user['address'])
-        self.birthdate = user.get('birthdate', '')
-        if 'device' in user:
+        if (user['device']):
             self.address = Device(user['device'])
 
 
 class Address(object):
-    def __init__(self, json):
-        address = loads(json)
+    def __init__(self, address):
         self.country = address.get('country', '')
         self.street_address = address.get('street_address', '')
         self.locality = address.get('locality', '')
@@ -52,8 +50,7 @@ class Address(object):
 
 
 class Eid(object):
-    def __init__(self, json):
-        eid = loads(json)
+    def __init__(self, eid):
         self.eid = eid.get('eid', '')
         self.issuance_locality = eid.get('issuance_locality', '')
         self.national_number = eid.get('national_number', '')
@@ -63,8 +60,7 @@ class Eid(object):
 
 
 class Device(object):
-    def __init__(self, json):
-        device = loads(json)
+    def __init__(self, device):
         self.os = device.get('os', '')
         self.app_name = device.get('appName', '')
         self.app_release = device.get('appRelease', '')
@@ -93,9 +89,9 @@ class ItsmeSettings(object):
 class UrlConfiguration(object):
     def __init__(self, scopes: List[str], service_code: str, redirect_uri: str, request_uri: str):
         self.scopes = scopes
+        self.service_code = service_code
         self.redirect_uri = redirect_uri
         self.request_uri = request_uri
-        self.service_code = service_code
 
 
 class RedirectData(object):
@@ -113,8 +109,27 @@ class RequestURIConfiguration(object):
         self.claims = claims
 
 
+# Itsme Environments
 PRODUCTION = 'production'
 SANDBOX = 'e2e'
+
+# Claims
+# ACRBasic will allow the user to use biometric authentication
+ACRBasic = "tag:sixdots.be,2016-06:acr_basic"
+# ACRAdvanced will force the use of the pinpad
+ACRAdvanced = "tag:sixdots.be,2016-06:acr_advanced"
+# ACRSecured does stuff that's not documented
+ACRSecured = "tag:sixdots.be,2016-06:acr_secured"
+# ClaimEid requests the user's EID data
+ClaimEid = "tag:sixdots.be,2016-06:claim_eid"
+# ClaimCityOfBirth requests the user's city of birth
+ClaimCityOfBirth = "tag:sixdots.be,2016-06:claim_city_of_birth"
+# ClaimNationality requests the user's nationality
+ClaimNationality = "tag:sixdots.be,2016-06:claim_nationality"
+# ClaimDevice requests the user's device information
+ClaimDevice = "tag:sixdots.be,2017-05:claim_device"
+# ClaimPhoto requests the user's picture
+ClaimPhoto = "tag:sixdots.be,2017-05:claim_photo"
 
 
 class Client(object):
@@ -161,7 +176,7 @@ class Client(object):
             error = Error(response.error.decode('utf-8'))
             raise ValueError(error.message)
         return User(response.data.decode('utf-8'))
-    
+
     def create_request_uri_payload(self, request_uri_config: RequestURIConfiguration) -> str:
         request_uri_config.url_config = request_uri_config.url_config.__dict__
         request_uri_config_serialized = dumps(request_uri_config.__dict__)

--- a/python/itsme/itsme.py
+++ b/python/itsme/itsme.py
@@ -5,6 +5,38 @@ from os.path import abspath, dirname
 from sys import platform as operating_system
 
 
+def has_truthy_attr(name: str, d: dict):
+    return bool(name in d and d[name])
+
+
+# Itsme Environments
+class AppEnvironments:
+    PRODUCTION = "production"
+    E2E = "e2e"
+
+
+class ACRValues:
+    # ACRBasic will allow the user to use biometric authentication
+    ACRValues = "tag:sixdots.be,2016-06:acr_basic"
+    # ACRAdvanced will force the use of the pinpad
+    ACRAdvanced = "tag:sixdots.be,2016-06:acr_advanced"
+    # ACRSecured does stuff that's not documented
+    ACRSecured = "tag:sixdots.be,2016-06:acr_secured"
+
+
+class Claims:
+    # Eid requests the user's EID data
+    Eid = "tag:sixdots.be,2016-06:claim_eid"
+    # ClaimCityOfBirth requests the user's city of birth
+    CityOfBirth = "tag:sixdots.be,2016-06:claim_city_of_birth"
+    # Nationality requests the user's nationality
+    Nationality = "tag:sixdots.be,2016-06:claim_nationality"
+    # Device requests the user's device information
+    Device = "tag:sixdots.be,2017-05:claim_device"
+    # Photo requests the user's picture
+    Photo = "tag:sixdots.be,2017-05:claim_photo"
+
+
 class Response(Structure):
     _fields_ = [('data', c_char_p), ('error', c_char_p)]
 
@@ -33,11 +65,11 @@ class User(object):
         self.birthdate = user.get('birthdate', '')
         self.city_of_birth = user.get('city_of_birth', '')
         self.photo = user.get('photo', '')
-        if (user['eid']):
+        if (has_truthy_attr("eid", user)):
             self.eid = Eid(user['eid'])
-        if (user['address']):
+        if (has_truthy_attr("address", user)):
             self.address = Address(user['address'])
-        if (user['device']):
+        if (has_truthy_attr("device", user)):
             self.address = Device(user['device'])
 
 
@@ -107,29 +139,6 @@ class RequestURIConfiguration(object):
         self.nonce = nonce
         self.state = state
         self.claims = claims
-
-
-# Itsme Environments
-PRODUCTION = 'production'
-SANDBOX = 'e2e'
-
-# Claims
-# ACRBasic will allow the user to use biometric authentication
-ACRBasic = "tag:sixdots.be,2016-06:acr_basic"
-# ACRAdvanced will force the use of the pinpad
-ACRAdvanced = "tag:sixdots.be,2016-06:acr_advanced"
-# ACRSecured does stuff that's not documented
-ACRSecured = "tag:sixdots.be,2016-06:acr_secured"
-# ClaimEid requests the user's EID data
-ClaimEid = "tag:sixdots.be,2016-06:claim_eid"
-# ClaimCityOfBirth requests the user's city of birth
-ClaimCityOfBirth = "tag:sixdots.be,2016-06:claim_city_of_birth"
-# ClaimNationality requests the user's nationality
-ClaimNationality = "tag:sixdots.be,2016-06:claim_nationality"
-# ClaimDevice requests the user's device information
-ClaimDevice = "tag:sixdots.be,2017-05:claim_device"
-# ClaimPhoto requests the user's picture
-ClaimPhoto = "tag:sixdots.be,2017-05:claim_photo"
 
 
 class Client(object):

--- a/python/itsme/itsme.py
+++ b/python/itsme/itsme.py
@@ -91,10 +91,17 @@ class ItsmeSettings(object):
 
 
 class UrlConfiguration(object):
-    def __init__(self, scopes: List[str], service_code: str, request_uri: str):
+    def __init__(self, scopes: List[str], service_code: str, redirect_uri: str, request_uri: str):
         self.scopes = scopes
+        self.redirect_uri = redirect_uri
         self.request_uri = request_uri
         self.service_code = service_code
+
+
+class RedirectData(object):
+    def __init__(self, code: str, redirect_uri: str):
+        self.code = code
+        self.redirect_uri = redirect_uri
 
 
 class RequestURIConfiguration(object):
@@ -147,8 +154,9 @@ class Client(object):
             raise ValueError(error.message)
         return response.data.decode('utf-8')
 
-    def get_user_details(self, authorization_code: str = None) -> User:
-        response = self.itsme_lib.GetUserDetails(bytes(authorization_code, 'utf-8'))
+    def get_user_details(self, redirect_data: RedirectData) -> User:
+        serialized_redirect_data = dumps(redirect_data.__dict__)
+        response = self.itsme_lib.GetUserDetails(bytes(serialized_redirect_data, 'utf-8'))
         if response.error:
             error = Error(response.error.decode('utf-8'))
             raise ValueError(error.message)

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from subprocess import call
 
 # Download ITSME libraries
 lib_version = '0.5.0.1579093712'
-version = '0.0.6'
+version = '0.0.7'
 location = './itsme'
 
 if operating_system == 'nt':
@@ -22,6 +22,11 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/itsme-api/itsme-api-python',
     packages=find_packages(),
+    # Wheel distributation does not honor Manifest.in for python 3
+    # we have to include binary files here
+    package_data={
+        'itsme': ['itsme_lib.dll', 'itsme_lib.dylib', 'itsme_lib.so'],
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,10 +7,15 @@ lib_version = '0.5.0.1579093712'
 version = '0.0.7'
 location = './itsme'
 
+fetch_deps_exit_code = None
+
 if operating_system == 'nt':
-    call(f'../scripts/dependencies.ps1 -libVersion {lib_version} -location {location}', shell=True)
+    fetch_deps_exit_code = call(f'../scripts/dependencies.ps1 -libVersion {lib_version} -location {location}', shell=True)
 else:
-    call(f'../scripts/dependencies.sh {lib_version} {location}', shell=True)
+    fetch_deps_exit_code = call(f'../scripts/dependencies.sh {lib_version} {location}', shell=True)
+
+if fetch_deps_exit_code != 0:
+    raise SystemExit("Failed to fetch dependencies")
 
 setup(
     name='itsme',

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from subprocess import call
 
 # Download ITSME libraries
 lib_version = '0.5.0.1579093712'
-version = '0.0.7'
+version = '0.0.8'
 location = './itsme'
 
 fetch_deps_exit_code = None

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -24,6 +24,6 @@ fi
 for EXTENSION in "${EXTENSIONS[@]}"
 do
     FILE_NAME="itsme_lib.${EXTENSION}"
-    curl -o "${LOCATION}/${FILE_NAME}" "https://github.com/itsme-sdk/itsme-golang/releases/download/v${VERSION}/${FILE_NAME}" || exit 1
+    curl -L -f -o "${LOCATION}/${FILE_NAME}" "https://github.com/itsme-sdk/itsme-golang/releases/download/v${VERSION}/${FILE_NAME}" || exit 1
     echo "Successfully downloaded ${FILE_NAME}"
 done


### PR DESCRIPTION
In the bash script curl was returning 302, and instead of binary files we were packaging html responses. Adding `-L` flag helped there.
The rest is just updating data model and demo.
This version does not include free text templates yet, I will add it later.